### PR TITLE
Restore State from URL

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import react from 'eslint-plugin-react';
 import tseslint from 'typescript-eslint';
 import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import reactCompiler from 'eslint-plugin-react-compiler';
-import nextPlugin from "@next/eslint-plugin-next";
+import nextPlugin from '@next/eslint-plugin-next';
 
 export default tseslint.config([
   { ignores: ['dist', 'coverage', 'node_modules'] },
@@ -14,8 +14,7 @@ export default tseslint.config([
     extends: [
       js.configs.recommended,
       ...tseslint.configs.strict,
-      eslintPluginPrettier,
-      nextPlugin.configs["core-web-vitals"]
+      eslintPluginPrettier
     ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
@@ -27,7 +26,7 @@ export default tseslint.config([
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
       'react-compiler': reactCompiler,
-      "@next/next": nextPlugin,
+      '@next/next': nextPlugin,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
@@ -38,6 +37,7 @@ export default tseslint.config([
       'react-compiler/react-compiler': 'error',
       ...react.configs.recommended.rules,
       ...react.configs['jsx-runtime'].rules,
+      ...nextPlugin.configs['core-web-vitals'].rules,
     },
     settings: {
       react: {

--- a/src/app/[locale]/rest/[method]/[[...requestpart]]/page.tsx
+++ b/src/app/[locale]/rest/[method]/[[...requestpart]]/page.tsx
@@ -1,8 +1,18 @@
 import { CodeGenerator } from '@components';
+import dynamic from 'next/dynamic';
+
+const RestClientLazy = dynamic(
+  () =>
+    import('../../../../../components/RestClient/RestClient').then(
+      (m) => m.RestClient
+    ),
+  { loading: () => <p>Loading...</p> }
+);
 
 export default function RestClientPage() {
   return (
     <div className="flex justify-end w-full">
+      <RestClientLazy />
       <CodeGenerator
         request={{
           method: 'GET',

--- a/src/components/FallBackUI/FallBackUI.tsx
+++ b/src/components/FallBackUI/FallBackUI.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { FC } from 'react';
 
 export const FallbackUI: FC<{ onReset?: () => void }> = ({ onReset }) => {

--- a/src/components/RestClient/RestClient.tsx
+++ b/src/components/RestClient/RestClient.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { FC, useState } from 'react';
+import { RequestType } from '@types';
+import { useParams, useSearchParams } from 'next/navigation';
+import { convertUrlToRequest } from '@utils/requestUrlConverter';
+
+export const RestClient: FC = () => {
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const [request] = useState<RequestType>(
+    convertUrlToRequest(params, searchParams)
+  );
+  return (
+    <pre>
+      {`Current state:
+        Method: ${request.method}
+        URL: ${request.url ?? 'No URL provided'}
+        Body: ${request.body ?? 'No body provided'}
+        Headers: ${
+          request.headers
+            ? Object.entries(request.headers)
+                .map(([key, value]) => `${key}: ${value}`)
+                .join('\n  ')
+            : 'No headers provided'
+        }`}
+    </pre>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export * from './CodeGenerator/ButtonCopy';
 export * from './ErrorBoundary/ErrorBoundary';
 export * from './FallBackUI/FallBackUI';
 export * from './Toast/Toast';
+export * from './RestClient/RestClient';

--- a/src/test-data/request-url-converter-data.ts
+++ b/src/test-data/request-url-converter-data.ts
@@ -1,0 +1,43 @@
+import { ReadonlyURLSearchParams } from 'next/navigation';
+
+export const urlFull =
+  '/aHR0cDovL2xvY2FsaG9zdDo4MDgw/' +
+  'ewogICJ0ZXh0IjogInRleHQiLAogICJvYmplY3QiOiB7CiAgICAicHJvcDEiOiAicHJvcDEiLAo' +
+  'gICAgInByb3AyIjogInByb3AyIgogIH0KfQ' +
+  '?Content-Type=application%2Fjson&Accept=application%2Fjson';
+
+export const urlMethodOnly = '';
+
+export const requestFull = {
+  method: 'GET',
+  url: 'http://localhost:8080',
+  body:
+    '{\n' +
+    '  "text": "text",\n' +
+    '  "object": {\n' +
+    '    "prop1": "prop1",\n' +
+    '    "prop2": "prop2"\n' +
+    '  }\n' +
+    '}',
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
+};
+
+export const requestMethodOnly = {
+  method: 'GET',
+};
+
+export const paramsFull = {
+  method: 'GET',
+  requestpart: [
+    'aHR0cDovL2xvY2FsaG9zdDo4MDgw',
+    'ewogICJ0ZXh0IjogInRleHQiLAogICJvYmplY3QiOiB7CiAgICAicHJvcDEiOiAicHJvcDEiLAogICAgInByb3AyIjogInByb3AyIgogIH0KfQ',
+  ],
+};
+
+export const searchParams = new URLSearchParams({
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+}) as unknown as ReadonlyURLSearchParams;

--- a/src/utils/requestUrlConverter.test.ts
+++ b/src/utils/requestUrlConverter.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  convertRequestToUrl,
+  convertUrlToRequest,
+} from '@utils/requestUrlConverter';
+import {
+  paramsFull,
+  requestFull,
+  requestMethodOnly,
+  searchParams,
+  urlFull,
+  urlMethodOnly,
+} from '../test-data/request-url-converter-data';
+
+describe('Request-url converter tests', () => {
+  it('Should convert url to request successfully', () => {
+    expect(convertUrlToRequest(paramsFull, searchParams)).toStrictEqual(
+      requestFull
+    );
+  });
+
+  it('Should convert request to url successfully', () => {
+    expect(convertRequestToUrl(requestFull)).toBe(urlFull);
+    expect(convertRequestToUrl(requestMethodOnly)).toBe(urlMethodOnly);
+  });
+});

--- a/src/utils/requestUrlConverter.ts
+++ b/src/utils/requestUrlConverter.ts
@@ -1,0 +1,36 @@
+import { Params } from 'next/dist/server/request/params';
+import { ReadonlyURLSearchParams } from 'next/navigation';
+import { RequestType } from '@types';
+import { base64ToString, stringToBase64 } from '@utils/stringBase64Converter';
+
+export function convertUrlToRequest(
+  params: Params,
+  searchParams?: ReadonlyURLSearchParams
+): RequestType {
+  const paramsObj: Record<string, string> = {};
+  if (searchParams) {
+    searchParams.forEach((value, key) => {
+      paramsObj[key] = value;
+    });
+  }
+  return {
+    method: params.method?.toString() ?? '',
+    url: base64ToString(params.requestpart ? params.requestpart[0] : undefined),
+    body: base64ToString(
+      params.requestpart ? params.requestpart[1] : undefined
+    ),
+    headers: paramsObj,
+  };
+}
+
+export function convertRequestToUrl(request: RequestType): string {
+  const searchParams = new URLSearchParams();
+  if (request.headers) {
+    Object.entries(request.headers).forEach(([key, value]) =>
+      searchParams.append(key, value)
+    );
+  }
+  const urlPart = request.url ? `/${stringToBase64(request.url)}` : '';
+  const bodyPart = request.body ? `/${stringToBase64(request.body)}` : '';
+  return `${urlPart}${bodyPart}${request.headers ? `?${searchParams}` : ''}`;
+}

--- a/src/utils/stringBase64Converter.test.ts
+++ b/src/utils/stringBase64Converter.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { base64ToString, stringToBase64 } from './stringBase64Converter';
+
+const text = 'http://localhost:8080';
+const base64Text = 'aHR0cDovL2xvY2FsaG9zdDo4MDgw';
+
+describe('Test stringBase64Converter functions', () => {
+  it('Should encode string to base64 correctly', () => {
+    expect(stringToBase64(text)).toBe(base64Text);
+  });
+
+  it('Should decode base64 to string correctly', () => {
+    expect(base64ToString(base64Text)).toBe(text);
+  });
+
+  it('Should throw an error if not base64 string was provided', () => {
+    expect(() => base64ToString('bad string')).toThrow();
+  });
+
+  it('Should return undefined for undefined', () => {
+    expect(base64ToString(undefined)).toBe(undefined);
+    expect(stringToBase64(undefined)).toBe(undefined);
+  });
+});

--- a/src/utils/stringBase64Converter.ts
+++ b/src/utils/stringBase64Converter.ts
@@ -1,0 +1,31 @@
+export function stringToBase64(text: string | undefined): string | undefined {
+  if (text === undefined) return undefined;
+  return Buffer.from(text, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+export function base64ToString(base64: string | undefined): string | undefined {
+  if (base64 === undefined) return undefined;
+  const base64Regex =
+    /^(?:[A-Za-z0-9\-_]{4})*(?:[A-Za-z0-9\-_]{2}==|[A-Za-z0-9\-_]{3}=)?$/;
+
+  let normalized = base64.replace(/-/g, '+').replace(/_/g, '/');
+
+  while (normalized.length % 4 !== 0) {
+    normalized += '=';
+  }
+
+  if (!base64Regex.test(normalized)) {
+    throw new Error('Invalid base64');
+  }
+
+  const decoded = Buffer.from(base64, 'base64')
+    .toString('utf-8')
+    .replaceAll(/\r\n/g, '\n')
+    .replaceAll('\x00', '');
+
+  return decoded.trim();
+}


### PR DESCRIPTION
## 🧾 Description

- implemented functions to restore state (user defined request parameters - url, body, headers) from the app url (e.g /rest/GET/aHR0cDovL2xvY2FsaG9zdDo4MDgw/ewogICJ0ZXh0IjogInRleHQiLAogICJvYmplY3QiOiB7CiAgICAicHJvcDEiOiAicHJvcDEiLAogICAgInByb3AyIjogInByb3AyIgogIH0KfQ?Content-Type=application%2Fjson to the `{
  method: GET,
  url: http://localhost:8080,
  body: {
      "text": "text",
      "object": {
        "prop1": "prop1",
        "prop2": "prop2"
      }
  },
  headers: {
    Content-Type: application/json
  }
})` and vice versa

## ✅ Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code without changing functionality)
- [ ] Documentation update
- [ ] Style/Cosmetic changes

## 📷 Screenshot for UI changes

- <img width="1918" height="868" alt="image" src="https://github.com/user-attachments/assets/e2da7c08-570e-4249-b205-76d4f11e5cad" />

## 📌 Related Issues

- closes [#39](https://github.com/heresyhawkins/rest-client-app/issues/39)

## 💡 Notes for Reviewers

- To test functionality you can use [https://www.base64encode.org/](https://www.base64encode.org/) with `Perform URL-safe encoding (uses Base64URL format).`
